### PR TITLE
fixed some 500 errors for audio files

### DIFF
--- a/hummedia/models.py
+++ b/hummedia/models.py
@@ -8,7 +8,8 @@ class IsoDate(CustomType):
     init_type = None
 
     def to_bson(self, value):
-        return unicode(datetime.datetime.strftime(value,'%Y-%m-%d'))
+        if value is not None:
+            return unicode(datetime.datetime.strftime(value,'%Y-%m-%d'))
 
     def to_python(self, value):
         if value is not None:

--- a/hummedia/resources.py
+++ b/hummedia/resources.py
@@ -807,6 +807,8 @@ class AssetGroup(Resource):
 
                     if vid["@graph"]["type"]=="humvideo":
                         needs_ext=True
+                    elif payload['@graph']['type']=='humaudio':
+                        needs_ext=True
                     elif vid["@graph"]["type"]=="yt":
                         needs_ext=False
                     for location in vid["@graph"]["ma:locator"]:


### PR DESCRIPTION
This fixes two forms of 500 errors. One is a result of None values getting serialized incorrectly by to_bson() when dates are expected.

The second issue causes problems for modifying audio items.
